### PR TITLE
Update WRT supply

### DIFF
--- a/src/tokens/c0ee29a85b13209423b10447d3c2e6a50641a15c57770e27cb9d507357696e67526964657273.yaml
+++ b/src/tokens/c0ee29a85b13209423b10447d3c2e6a50641a15c57770e27cb9d507357696e67526964657273.yaml
@@ -16,3 +16,7 @@ verified: true
 
 decimals: 6
 
+maxSupply: 100000000000000
+
+circulatingOnChain:
+  - https://api.mainnet.wingriders.com/wrt-circulating-supply


### PR DESCRIPTION
- Added max supply: 100M + 6 decimals
- Added circulating supply - fetched from https://api.mainnet.wingriders.com/wrt-circulating-supply