### PR TITLE
Add metadata for $ORACLE token

### DIFF
--- a/tokens/meta.json
+++ b/tokens/meta.json
@@ -1,5 +1,5 @@
 {
-  "name": "$ORACLE",
+  "name": "ORACLE",
   "policy_id": "7a0c09d9300f43535780a985fa43d490a4e448ee9e7aa990cb3affe8",
   "symbol": "$ORACLE",
   "website": "https://oracleonada.fun/",

--- a/tokens/meta.json
+++ b/tokens/meta.json
@@ -1,0 +1,9 @@
+{
+  "name": "$ORACLE",
+  "policy_id": "7a0c09d9300f43535780a985fa43d490a4e448ee9e7aa990cb3affe8",
+  "symbol": "$ORACLE",
+  "website": "https://oracleonada.fun/",
+  "twitter": "https://x.com/oracleonada/status/1870478294971515169",
+  "decimals": 6,
+  "description": "A Cardano token designed to interact with the Oracle terminal, striving to unify the community."
+}


### PR DESCRIPTION
This pull request adds the metadata for the $ORACLE token to the Minswap tokens repository.

Details:
Token Name: $ORACLE
Policy ID: 7a0c09d9300f43535780a985fa43d490a4e448ee9e7aa990cb3affe8
Decimals: 6
Website: https://oracleonada.fun/
Twitter Announcement: https://x.com/oracleonada/status/1870478294971515169
Description: A Cardano token designed to interact with the Oracle terminal, striving to unify the community.