### PR TITLE
Add Agent Lump (LUMP) token verification

### DIFF
--- a/src/tokens/73797786382c0832b5787a5b306f5308488f14571b7061f79396ad2c4c756d70.yaml
+++ b/src/tokens/73797786382c0832b5787a5b306f5308488f14571b7061f79396ad2c4c756d70.yaml
@@ -1,0 +1,25 @@
+# 1 token = 1 yaml file
+# assetId (file name) = policyId + hex asset name
+#   policyId   = 73797786382c0832b5787a5b306f5308488f14571b7061f79396ad2c
+#   assetName  = 4c756d70  ("Lump")
+
+project: Agent Lump
+
+# among: DeFi, RealFi, GameFi, Meme, Bridge, Metaverse, Wallet, NFT, Oracle,
+#        AI, Launchpad, DAO, Stablecoin, Social, Media, Risk Ratings,
+#        Index Vaults, DePIN, Other
+categories:
+  - AI
+  - Meme
+
+# must match the Cardano Token Registry decimals (0)
+decimals: 0
+
+socialLinks:
+  website: https://lumptools.xyz
+  twitter: https://x.com/AgentLumpAI
+
+verified: true
+
+# 1,000,000,000 LUMP, 0 decimals (single Plutus mint, fully circulating)
+maxSupply: 1000000000


### PR DESCRIPTION
Adds verification for **Agent Lump ($LUMP)**.

- **Asset ID:** `73797786382c0832b5787a5b306f5308488f14571b7061f79396ad2c4c756d70` (policy `73797786382c0832b5787a5b306f5308488f14571b7061f79396ad2c`, asset name `4c756d70` = "Lump")
- **Decimals:** 0 — matches the Cardano Token Registry entry (merged in cardano-foundation/cardano-token-registry#7994).

Verification requirements:
- ✅ **Minswap pool ≥ 1000 ADA TVL** — LUMP/ADA pool live on Minswap (~51K ADA liquidity).
- ✅ **Logo** in the Cardano Token Registry (PR #7994, merged).
- ✅ **Policy ID public** — via the Cardano Token Registry entry and on https://lumptools.xyz; project X https://x.com/AgentLumpAI.
- ✅ **100 ADA verification fee** — tx `080c09fbe5c0fc2a168f9186172e5323e606e6be86028cde1ad443f3dcb41d36`.

Project: Agent Lump — Doomsday AI Agent building on Midnight and Cardano.
